### PR TITLE
platform: Use Nagra CMA Platform lib for init/term

### DIFF
--- a/MediaSystem/MediaSessionSystem.h
+++ b/MediaSystem/MediaSessionSystem.h
@@ -18,6 +18,7 @@
 
 #include <interfaces/IDRM.h> 
 
+#include <nagra/nagra_cma_platf.h>
 #include <nagra/prm_asm.h>
 #include <nagra/nv_imsm.h>
 

--- a/MediaSystem/MediaSystem.cpp
+++ b/MediaSystem/MediaSystem.cpp
@@ -28,14 +28,23 @@ namespace {
 
     public:
         CCLInitialize() {
-            bool result = nvInitialize();
-            if ( result == false ) {
-                REPORT("Call to nvInitialize failed");
+            int rc = nagra_cma_platf_init();
+            if ( rc == NAGRA_CMA_PLATF_OK ) {
+                bool result = nvInitialize();
+                if ( result == false ) {
+                    REPORT("Call to nvInitialize failed");
+                }
+            } else {
+                REPORT_EXT("Call to nagra_cma_platf_init failed (%d)", rc);
             }
         }
 
         ~CCLInitialize() {
             nvTerminate();
+            int rc = nagra_cma_platf_term();
+            if ( rc != NAGRA_CMA_PLATF_OK ) {
+                REPORT_EXT("Call to nagra_cma_platf_term failed (%d)", rc);
+            }
         }
 
     };


### PR DESCRIPTION
The Nagra CMA library is initialized/terminated by calling the
nvInitialize()/nvTerminate() functions. However, there are cases where
platform specific initializations are required for nvInitialize() to
succeed. This is the case of the platform where this plugin is being
tested.

This way, the 'nagra-cma' package is now exporting a new library with an
API function (nagra_cma_platf_init) that must be used for initializing
the platform before calling nvInitialize(). Conversely, there's also an
API function for terminating the platform (nagra_cma_platf_init) that
must be called after nvTerminate().

Include the new API functions through the new <nagra/nagra_cma_platf.h>
header file and use nagra_cma_platf_init()/nagra_cma_platf_term() as
described.

The new Nagra CMA package config files export the new required library,
so no changes required for linking with it.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>